### PR TITLE
Use default 2204 image with included virtual MIDI drivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 defaults: &defaults
   machine:
-    image: ubuntu-2004-cuda-11.4:202110-01
+    image: default
   resource_class: medium
 
 jobs:


### PR DESCRIPTION
For newer Ubuntu versions, it's no-longer required to use this trick to pin your image to GCP.